### PR TITLE
Reworded the "edit" button.

### DIFF
--- a/pasttle/server.py
+++ b/pasttle/server.py
@@ -198,7 +198,7 @@ def _pygmentize(paste, lang):
             lexer = lexers.get_lexer_by_name('text')
     else:
         lexer = lexers.get_lexer_for_mimetype(paste.mimetype)
-    a = '<small><a href="/edit/%s">edit</a></small>' % (paste.id,)
+    a = '<small><a href="/edit/%s">edit as new paste</a></small>' % (paste.id,)
     if paste.ip:
         ip = IPy.IP(long(paste.ip, 2))
         util.log.debug('Originally pasted from %s' % (ip,))


### PR DESCRIPTION
When using Pasttle, I edited a paste (thinking it would update the existing one) then told others to reload. They didn't see a change & I didn't realize editing created a whole new paste with a different URL. This rewords the link to be clearer about what's going on.
